### PR TITLE
Buffer chafter

### DIFF
--- a/Source/Audio/shaper~.c
+++ b/Source/Audio/shaper~.c
@@ -215,7 +215,7 @@ static void *shaper_new(t_symbol *s, int ac, t_atom *av){
                 goto errstate;
         }
     };
-    x->x_buffer = buffer_init((t_class *)x, name, 1, 0);
+    x->x_buffer = buffer_init((t_class *)x, name, 1, 0, 0); // just added fifth argument: see buffer.c / buffer.h 
     if(!x->x_arrayset)
         update_cheby_func(x);
     outlet_new(&x->x_obj, gensym("signal"));

--- a/Source/Audio/tabreader~.c
+++ b/Source/Audio/tabreader~.c
@@ -11,6 +11,8 @@ typedef struct _tabreader{
     int       x_ch;
     int       x_idx;
     int       x_loop;
+    // new var to store namemode: 0 = <ch>-<arrayname>, 1 = <arrayname>-<ch> 
+    int       x_namemode;         // 0 is <ch>-<arrayname>, 1 is <arrayname>-<ch>
     t_float	  x_bias;
     t_float   x_tension;
 }t_tabreader;
@@ -155,10 +157,18 @@ static void *tabreader_new(t_symbol *s, int ac, t_atom * av){
     x->x_idx = x->x_loop = 0;
     x->x_bias = x->x_tension = 0;
     x->x_i_mode = 5; // spline
+    // new var to store namemode: 0 = <ch>-<arrayname>, 1 = <arrayname>-<ch>
+    x->x_namemode = 0;
 	while(ac){
 		if(av->a_type == A_SYMBOL){ // symbol
             t_symbol * curarg = atom_getsymbolarg(0, ac, av);
-            if(curarg == gensym("-none")){
+            // added flag to set namemode: 0 = <ch>-<arrayname>, 1 = <arrayname>-<ch>
+            if(curarg == gensym("-chafter")){
+                if(nameset)
+                    goto errstate;
+            x->x_namemode = 1; ac--, av++;
+            } 
+            else if(curarg == gensym("-none")){
                 if(nameset)
                     goto errstate;
                 tabreader_set_nointerp(x), ac--, av++;
@@ -232,7 +242,13 @@ static void *tabreader_new(t_symbol *s, int ac, t_atom * av){
         }
 	};
     x->x_ch = (ch < 0 ? 1 : ch > 64 ? 64 : ch);
-    x->x_buffer = buffer_init((t_class *)x, name, 1, x->x_ch);
+    // init buffer according to namemode: 0 = <ch>-<arrayname>, 1 = <arrayname>-<ch>
+    if(x->x_namemode == 0) {
+        x->x_buffer = buffer_init((t_class *)x, name, 1, x->x_ch, 0); /// new arg added 0: <ch>-<arrayname> mode / 1: <arrayname>-<ch> mode !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    }
+    else if(x->x_namemode == 1){
+        x->x_buffer = buffer_init((t_class *)x, name, 1, x->x_ch, 1); 
+    }    
     buffer_getchannel(x->x_buffer, x->x_ch, 1);
     buffer_setminsize(x->x_buffer, 2);
     buffer_playcheck(x->x_buffer);

--- a/Source/Audio/wavetable~.c
+++ b/Source/Audio/wavetable~.c
@@ -401,7 +401,7 @@ static void *wavetable_new(t_symbol *s, int ac, t_atom *av){
             ac--, av++;
         }
     }
-    x->x_buffer = buffer_init((t_class *)x, name, 1, 0);
+    x->x_buffer = buffer_init((t_class *)x, name, 1, 0, 0); // just added fifth argument: see buffer.c / buffer.h 
     x->x_phase[0] = phaseoff < 0 || phaseoff > 1 ? 0 : phaseoff;
     x->x_inlet_sync = inlet_new((t_object *)x, (t_pd *)x, &s_signal, &s_signal);
 //        pd_float((t_pd *)x->x_inlet_sync, 0);

--- a/Source/Audio/wt2d~.c
+++ b/Source/Audio/wt2d~.c
@@ -441,7 +441,7 @@ static void *wt2d_new(t_symbol *s, int ac, t_atom *av){
         }
     }
     x->x_nframes = x->x_columns * x->x_rows;
-    x->x_buffer = buffer_init((t_class *)x, name, 1, 0);
+    x->x_buffer = buffer_init((t_class *)x, name, 1, 0, 0); // just added fifth argument: see buffer.c / buffer.h 
     x->x_phase[0] = phaseoff < 0 || phaseoff > 1 ? 0 : phaseoff;
     x->x_inlet_sync = inlet_new((t_object *)x, (t_pd *)x, &s_signal, &s_signal);
         pd_float((t_pd *)x->x_inlet_sync, 0);

--- a/Source/Extra/Aliases/wt~.c
+++ b/Source/Extra/Aliases/wt~.c
@@ -402,7 +402,7 @@ static void *wt_new(t_symbol *s, int ac, t_atom *av){
             }
         }
     }
-    x->x_buffer = buffer_init((t_class *)x, name, 1, 0);
+    x->x_buffer = buffer_init((t_class *)x, name, 1, 0 , 0); // just added fifth argument: see buffer.c / buffer.h 
     x->x_phase[0] = phaseoff < 0 || phaseoff > 1 ? 0 : phaseoff;
     x->x_inlet_sync = inlet_new((t_object *)x, (t_pd *)x, &s_signal, &s_signal);
         pd_float((t_pd *)x->x_inlet_sync, 0);

--- a/Source/Shared/buffer.h
+++ b/Source/Shared/buffer.h
@@ -33,6 +33,8 @@ typedef struct _buffer{
     int         c_disabled;
     int         c_single;    // flag: 0-regular mode, 1-load this particular channel (1-idx)
                              // should be used with c_numchans == 1
+    // Now buffer will have a bufname mode: 0 - <ch>-<bufname> [default/legacy], 1 - <bufname>-<ch> 
+    int         c_bufnamemode; 
 }t_buffer;
 
 double interp_lin(double frac, double b, double c);
@@ -71,7 +73,8 @@ void buffer_setminsize(t_buffer *c, int i);
 void buffer_enable(t_buffer *c, t_floatarg f);
 
 // single channel mode used for poke~/peek~
-void *buffer_init(t_class *owner, t_symbol *bufname, int numchans, int singlemode);
+// Now buffer will have a bufname mode: 0 - <ch>-<bufname> [default/legacy], 1 - <bufname>-<ch>
+void *buffer_init(t_class *owner, t_symbol *bufname, int numchans, int singlemode, int bufnamemode); 
 void buffer_free(t_buffer *c);
 void buffer_checkdsp(t_buffer *c);
 void buffer_getchannel(t_buffer *c, int chan_num, int complain);


### PR DESCRIPTION
Adding option to [tabplay~], [tabreader~], [tabwriter~] and [tabreader] to work with multichannel arrays named <array>-<ch> instead of the default else pattern <ch>-<array>. For this, use -chafter as a flag when instantiating the object.

<ch> is always 0 indexed

